### PR TITLE
Add package and overlay to flake output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,24 +3,20 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = {
-    self,
-    nixpkgs,
-    flake-utils,
-  }:
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-      kak-popup = pkgs.callPackage ./default.nix {};
-    in {
-      packages = {
-        default = kak-popup;
-        kak-popup = kak-popup;
-      };
+  outputs = { self, nixpkgs, flake-utils, }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        kak-popup = pkgs.callPackage ./default.nix { };
+      in {
+        packages = {
+          default = kak-popup;
+          kak-popup = kak-popup;
+        };
 
-      devShells.default =
-        pkgs.mkShell {packages = with pkgs; [cargo clippy rustc tmux];};
-    })
-    // {
-      overlays.default = import ./overlay.nix;
-    };
+        devShells.default =
+          pkgs.mkShell { packages = with pkgs; [ cargo clippy rustc tmux ]; };
+      }) // {
+        overlays.default = import ./overlay.nix;
+      };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,24 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = nixpkgs.legacyPackages.${system};
-      in {
-        devShells.default =
-          pkgs.mkShell { packages = with pkgs; [ cargo clippy rustc tmux ]; };
-      });
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      kak-popup = pkgs.callPackage ./default.nix {};
+    in {
+      packages = {
+        default = kak-popup;
+        kak-popup = kak-popup;
+      };
+
+      devShells.default =
+        pkgs.mkShell {packages = with pkgs; [cargo clippy rustc tmux];};
+    })
+    // {
+      overlays.default = import ./overlay.nix;
+    };
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,3 +1,1 @@
-self: super: {
-  kak-popup = super.callPackage ./default.nix {};
-}
+self: super: { kak-popup = super.callPackage ./default.nix { }; }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,3 @@
+self: super: {
+  kak-popup = super.callPackage ./default.nix {};
+}


### PR DESCRIPTION
Should make it easier to be able to add this package declaratively to your system.

Just consume the overlay:
```nix
nixpkgs.overlays = [
  inputs.popup-kak.overlays.default
];
```
then install the package:
```nix
environment.systemPackages  = [
    pkgs.kak-popup
];
```