### PR TITLE
Configurable padding size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "kak-popup"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kak-popup"
 description = "kakoune popups"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "CC0-1.0"
 repository = "https://github.com/enricozb/tabs.kak"

--- a/rc/popup.kak
+++ b/rc/popup.kak
@@ -25,6 +25,7 @@ define-command -override popup -params 1.. -docstring '
               warn          show a modal with stderr
               dismiss       dismiss modal without running KAK_SCRIPT (default)
               ignore        ignore status and always run KAK_SCRIPT
+    --padding <size>        use <size> as popup window padding
 
 ' %{
   evaluate-commands %sh{

--- a/src/args.rs
+++ b/src/args.rs
@@ -45,6 +45,10 @@ pub struct Popup {
   #[arg(long)]
   pub width: usize,
 
+  /// The padding of the popup window.
+  #[arg(long, default_value_t = 16)]
+  pub padding: usize,
+
   /// Input to pass as stdin to COMMAND.
   #[arg(long)]
   pub input: Option<OsString>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ fn popup(args: PopupArgs) -> Result<()> {
       args.title,
       args.height,
       args.width,
+      args.padding,
       &command,
     )
     .context("Popup::new")?

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -19,20 +19,21 @@ pub struct Popup {
   keys_fifo: Fifo,
   resize_fifo: Fifo,
   commands_fifo: Fifo,
+
+  padding: usize,
 }
 
 impl Popup {
-  const PADDING: usize = 16;
-
   pub fn new(
     kakoune: Kakoune,
     keys_fifo: Fifo,
     title: Option<String>,
     height: usize,
     width: usize,
+    padding: usize,
     command: &[String],
   ) -> Result<Self> {
-    let size = Size { height, width }.padded(Self::PADDING)?;
+    let size = Size { height, width }.padded(padding)?;
 
     Ok(Self {
       tmux: Tmux::new(command, size)?,
@@ -43,6 +44,8 @@ impl Popup {
       keys_fifo,
       resize_fifo: Fifo::new("resize")?,
       commands_fifo: Fifo::new("commands")?,
+
+      padding,
     })
   }
 
@@ -94,7 +97,7 @@ impl Popup {
     )?;
 
     let resize = Resize::new(
-      Self::PADDING,
+      self.padding,
       self.tmux.clone(),
       self.resize_fifo.clone(),
       refresh.sender.clone(),

--- a/src/threads/keys.rs
+++ b/src/threads/keys.rs
@@ -90,6 +90,8 @@ impl<'a> Key<'a> {
       "space" => "Space",
       "backspace" => "BSpace",
       "del" => "DC",
+      "quote" => "'",
+      "dquote" => "\"",
       key => key,
     });
 

--- a/src/threads/keys.rs
+++ b/src/threads/keys.rs
@@ -39,7 +39,9 @@ impl Spawn for Keys {
       return Ok(Step::Quit);
     }
 
-    self.tmux.send_keys(&Key::from(key).into_tmux())?;
+    if ! key.starts_with("<mouse:") {
+      self.tmux.send_keys(&Key::from(key).into_tmux())?;
+    }
     self.commands_fifo.write(Self::CAPTURE_KEYS)?;
     self.refresh.send(())?;
 


### PR DESCRIPTION
Just  a quick change so the default padding used can be configured by the user via a command line flag.
It adds a new `--padding` command line flag that allows to specify the padding to be used.