### PR TITLE
Add support for quote and dquote keys

### DIFF
--- a/src/threads/keys.rs
+++ b/src/threads/keys.rs
@@ -138,6 +138,8 @@ impl<'a> From<Key<'a>> for TmuxKey {
           "minus" => "-",
           "percent" => "%",
           "semicolon" => "\\;",
+          "quote" => "'",
+          "dquote" => "\"",
           "up" => "Up",
           "down" => "Down",
           "left" => "Left",


### PR DESCRIPTION
Hi Enrico!

This PR adds support for the quote (') and dquote keys (") that, at least, weren't working for me (on WSL2 Ubuntu using Windows Terminal Emulator and on bare metal arch linux via ssh using blink shell) using the latest kakoune version built from source.